### PR TITLE
base and skip are not initialized in Bigint(std::string) constructor

### DIFF
--- a/src/bigint.cpp
+++ b/src/bigint.cpp
@@ -36,6 +36,8 @@ Bigint::Bigint(std::string stringInteger)
 {
     int size = stringInteger.length();
 
+    base = 1000000000;
+    skip = 0;
     positive = (stringInteger[0] != '-');
 
     while (true) {


### PR DESCRIPTION
If user construct a Bigint by using std::string(), then perform a mathematical calculation. It will throw a fatal error.

```
    Dodecahedron::Bigint a(std::string("20000")), b(std::string("9999"));
    a+=b;
```

This patch fix it by initialize "skip" and "base" in Bigint(std::string) constructor.
